### PR TITLE
feat: literal object argument support

### DIFF
--- a/src/examples/1.test.ts
+++ b/src/examples/1.test.ts
@@ -1,4 +1,4 @@
-import { minValue, Well } from "./1";
+import { minValue } from "./1";
 
 /**
  * BUG REPORT
@@ -7,11 +7,15 @@ import { minValue, Well } from "./1";
 describe("1", () => {
   // This test passes
   test("1a", () => {
-    expect(minValue([["2"], ["4"], ["1"]])).toStrictEqual(1);
+    expect(
+      minValue([{ valueText: 2 }, { valueText: 4 }, { valueText: 1 }])
+    ).toStrictEqual(1);
   });
 
   // Remove ".skip" to run this failing test
   test.skip("1b", () => {
-    expect(minValue([["2"], ["4"], ["0"]])).toStrictEqual(0);
+    expect(
+      minValue([{ valueText: 2 }, { valueText: 4 }, { valueText: 0 }])
+    ).toStrictEqual(0);
   });
 });

--- a/src/examples/1.ts
+++ b/src/examples/1.ts
@@ -1,21 +1,17 @@
 /**
  * Adapted from: https://stackoverflow.com/questions/58166594/
  *
- * Returns the min of values in an array of Wells.  If VALUE_TEXT is
- * not provided on the Well object, use VALUE to calculate min.
+ * Returns the min of values in an array of Wells.  If valueText is
+ * not provided on the Well object, use value to calculate min.
  *
  * @param wells An array of Well objects.  All Well objects have either a `valueText` or a `value` property.
  * @returns min of values in the Well objects
  */
-export function minValue(wells: [string?, number?][]): number {
-  return Math.min(
-    ...wells.map((d) => Number(d[VALUE_TEXT]) || Number(d[VALUE]))
-  );
+export function minValue(
+  wells: {
+    valueText?: number;
+    value?: number;
+  }[]
+): number {
+  return Math.min(...wells.map((d) => Number(d.valueText) || Number(d.value)));
 }
-
-/**
- * A valid Well object has at least one of: `valueText`, `value`
- */
-export type Well = [string?, number?];
-const VALUE_TEXT = 0;
-const VALUE = 1;

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -22,8 +22,7 @@ const floatOptions: FuzzOptions = {
  * for each example. TODO: Add tests that check the fuzzer output.
  */
 describe("Fuzzer", () => {
-  // TODO: Add support for tuple types !!!
-  test.skip("Fuzz example 1", async () => {
+  test("Fuzz example 1", async () => {
     const results = (
       await fuzz(setup(intOptions, "./src/examples/1.ts", "minValue"))
     ).results;
@@ -127,8 +126,7 @@ describe("Fuzzer", () => {
     expect(results.length).not.toStrictEqual(0);
   });
 
-  // TODO: Halt non-terminating tests
-  test.skip("Fuzz example 14", async () => {
+  test("Fuzz example 14", async () => {
     const results = (
       await fuzz(setup(intOptions, "./src/examples/14.ts", "modInv"))
     ).results;

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -300,7 +300,7 @@ export type FuzzOptions = {
   maxTests: number; // number of fuzzing tests to execute (>= 0)
   fnTimeout: number; // timeout threshold in ms per test
   suiteTimeout: number; // timeout for the entire test suite
-  // !!! oracleFn: typeof isReal; // TODO The oracle function !!!
+  // !!! oracleFn: // TODO The oracle function
 };
 
 /**

--- a/src/fuzzer/analysis/Typescript.test.ts
+++ b/src/fuzzer/analysis/Typescript.test.ts
@@ -18,7 +18,7 @@ describe("fuzzer/analysis/Typescript", () => {
   test("arrowFunction", () => {
     expect(
       getTsFnArgs(
-        `const $_f = (name: string, offset: number, happy: boolean, nums: number[][]):void => {
+        `const $_f = (name: string, offset: number, happy: boolean, nums: number[][], obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[]}):void => {
         const whatever:string = name + offset + happy + JSON.stringify(nums);}`,
         argOptions
       )
@@ -27,13 +27,21 @@ describe("fuzzer/analysis/Typescript", () => {
       new ArgDef("offset", 1, ArgTag.NUMBER, argOptions, 0),
       new ArgDef("happy", 2, ArgTag.BOOLEAN, argOptions, 0),
       new ArgDef("nums", 3, ArgTag.NUMBER, argOptions, 2),
+      new ArgDef("obj", 4, ArgTag.OBJECT, argOptions, 0, undefined, undefined, [
+        new ArgDef("num", 0, ArgTag.NUMBER, argOptions, 0),
+        new ArgDef("numA", 1, ArgTag.NUMBER, argOptions, 1),
+        new ArgDef("str", 2, ArgTag.STRING, argOptions, 0),
+        new ArgDef("strA", 3, ArgTag.STRING, argOptions, 1),
+        new ArgDef("bool", 4, ArgTag.BOOLEAN, argOptions, 0),
+        new ArgDef("boolA", 5, ArgTag.BOOLEAN, argOptions, 1),
+      ]),
     ]);
   });
 
   test("standardFunction", () => {
     expect(
       getTsFnArgs(
-        `function $_f(name: string, offset: number, happy: boolean, nums: number[][]):void {
+        `function $_f(name: string, offset: number, happy: boolean, nums: number[][], obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[]}):void {
         const whatever:string = name + offset + happy + JSON.stringify(nums);}`,
         argOptions
       )
@@ -42,6 +50,14 @@ describe("fuzzer/analysis/Typescript", () => {
       new ArgDef("offset", 1, ArgTag.NUMBER, argOptions, 0),
       new ArgDef("happy", 2, ArgTag.BOOLEAN, argOptions, 0),
       new ArgDef("nums", 3, ArgTag.NUMBER, argOptions, 2),
+      new ArgDef("obj", 4, ArgTag.OBJECT, argOptions, 0, undefined, undefined, [
+        new ArgDef("num", 0, ArgTag.NUMBER, argOptions, 0),
+        new ArgDef("numA", 1, ArgTag.NUMBER, argOptions, 1),
+        new ArgDef("str", 2, ArgTag.STRING, argOptions, 0),
+        new ArgDef("strA", 3, ArgTag.STRING, argOptions, 1),
+        new ArgDef("bool", 4, ArgTag.BOOLEAN, argOptions, 0),
+        new ArgDef("boolA", 5, ArgTag.BOOLEAN, argOptions, 1),
+      ]),
     ]);
   });
 


### PR DESCRIPTION
# Description

Add object literal support to fuzzer.  This allows NaNofuzz to analyze and fuzz functions with literal object arguments such as the following function's `wells` argument:

```
export function minValue(  wells: {
    valueText?: number;
    value?: number;
  }[]
): number {
  return Math.min(...wells.map((d) => Number(d.valueText) || Number(d.value)));
}
```

# Implementation strategy and design decisions

This change adds the notion that function arguments may have child arguments such that an object argument may contain `n` sub-arguments, each of which has the same attributes of any other argument.  A new generator function specific to object arguments loops over the object's children and randomizes their inputs in the same manner arguments have previously been randomized.

When the user is queried for range input by the VS Code extension, a similar process takes place whereby the user is queried for the ranges of each child argument of an object.