### PR TITLE
feat: Add Telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 
 # OS litter
 .DS_Store
+
+# Telemetry data
+/telemetry

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ NaNofuzz is a fast, easy-to-use automatic test generation tool for Typescript th
 
 <img width="1440" alt="image" src="https://user-images.githubusercontent.com/22134678/182907479-01dcf1dc-de09-4d55-af56-1837639d78af.png">
 
-Unlike some past automatic test generation tools, NaNofuzz takes an approach similar to fuzzing and uses a simple implicit oracle to determine whether or not a given test passes. NaNofuzz marks a test as failed if it:
+Unlike some past automatic test generation tools, NaNofuzz takes an approach similar to fuzzing and uses a simple implicit oracle to determine whether or not a given test passes. Surprisingly, this approach quickly finds many errors! NaNofuzz marks a test as failed if it:
  - throws a runtime exception
  - returns null, NaN, Infinity, or undefined
  - does not terminate within a configurable period of time
 
-Surprisingly, this approach quickly catches many errors! NaNofuzz supports standard and arrow functions with any mixture of the following parameter types:
+NaNofuzz supports standard and arrow functions with any mixture of the following parameter types:
  - Numbers (integers and floats, signed and unsigne)
  - Strings
  - Booleans
  - Literal object types
- - Arrays of any of the above
- - Optional parameters are supported
+ - n-dimension arrays of any of the above
+ - Optional and mandatory parameters
 
 The following are not yet supported:
  - Type references

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # NaNofuzz
-Numerical fuzzer for Typescript.  This is a research project and is not presently intended for real-world use.
+NaNofuzz is a fast, easy-to-use automatic test generation tool for Typescript that integrates with a developer's VS Code workflow.  We like working code, and NaNofuzz is designed to be used during initial development to more quickly reach working code nirvana.
+
+<img width="1440" alt="image" src="https://user-images.githubusercontent.com/22134678/182907479-01dcf1dc-de09-4d55-af56-1837639d78af.png">
+
+Unlike some past automatic test generation tools, NaNofuzz takes an approach similar to fuzzing and uses a simple implicit oracle to determine whether or not a given test passes. NaNofuzz marks a test as failed if it:
+ - throws a runtime exception
+ - returns null, NaN, Infinity, or undefined
+ - does not terminate within a configurable period of time
+
+Surprisingly, this approach quickly catches many errors! NaNofuzz supports standard and arrow functions with any mixture of the following parameter types:
+ - Numbers (integers and floats, signed and unsigne)
+ - Strings
+ - Booleans
+ - Literal object types
+ - Arrays of any of the above
+ - Optional parameters are supported
+
+The following are not yet supported:
+ - Type references
+ - OR types, Tuples, Generics, or Function parameters
+ - Deconstructed types
+ - Object methods
+
+These design choices allow NaNofuzz to be fast, lightweight, easy to integrate into an everyday workflow, and helps programmers quickly find important edge cases they may have missed.
+
+This is a research project and is not presently intended for production use.  

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
       {
         "command": "nanofuzz.Fuzz",
         "title": "AutoTest"
+      },
+      {
+        "command": "nanofuzz.telemetry.DumpLog",
+        "title": "Dump Telemetry Log"
+      },
+      {
+        "command": "nanofuzz.telemetry.ClearLog",
+        "title": "Clear Telemetry Log"
       }
     ],
     "menus": {
@@ -148,6 +156,32 @@
           "default": 0,
           "minimum": 0,
           "description": "Default number of array dimensions for any types.  0=not an array."
+        },
+        "nanofuzz.telemetry.timeoutMinutes": {
+          "title": "Timeout session after this many minutes (0=no timeout)",
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Number of minutes until session is automatically ended."
+        },
+        "nanofuzz.telemetry.purseCallbackUri": {
+          "title": "Telemetry update Url",
+          "type": "string",
+          "default": "",
+          "description": "Url target for telemetry updates.  (\"\" = no callback)"
+        },
+        "nanofuzz.telemetry.purseCallbackSecs": {
+          "title": "Telemtry update interval (seconds)",
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Interval (seconds) between telemetry pushes to URL. (0=no push)"
+        },
+        "nanofuzz.telemetry.purseCallbackKey": {
+          "title": "Telemetry key for this session",
+          "type": "string",
+          "default": "",
+          "description": "Key to use for telemetry updates. (\"\" = no key)"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -157,31 +157,12 @@
           "minimum": 0,
           "description": "Default number of array dimensions for any types.  0=not an array."
         },
-        "nanofuzz.telemetry.timeoutMinutes": {
-          "title": "Timeout session after this many minutes (0=no timeout)",
-          "type": "number",
-          "default": 0,
+        "telemetry.active": {
+          "title": "Activate telemetry? (requires restart)",
+          "type": "boolean",
+          "default": false,
           "minimum": 0,
-          "description": "Number of minutes until session is automatically ended."
-        },
-        "nanofuzz.telemetry.purseCallbackUri": {
-          "title": "Telemetry update Url",
-          "type": "string",
-          "default": "",
-          "description": "Url target for telemetry updates.  (\"\" = no callback)"
-        },
-        "nanofuzz.telemetry.purseCallbackSecs": {
-          "title": "Telemtry update interval (seconds)",
-          "type": "number",
-          "default": 0,
-          "minimum": 0,
-          "description": "Interval (seconds) between telemetry pushes to URL. (0=no push)"
-        },
-        "nanofuzz.telemetry.purseCallbackKey": {
-          "title": "Telemetry key for this session",
-          "type": "string",
-          "default": "",
-          "description": "Key to use for telemetry updates. (\"\" = no key)"
+          "description": "Activate telemetry? (requires restart)"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   ],
   "activationEvents": [
     "onCommand:nanofuzz.Fuzz",
+    "onCommand:nanofuzz.telemetry.log",
+    "onCommand:nanofuzz.telemetry.DumpLog",
+    "onCommand:nanofuzz.telemetry.ClearLog",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
     "onWebviewPanel:FuzzPanel"
@@ -51,6 +54,10 @@
       {
         "command": "nanofuzz.telemetry.ClearLog",
         "title": "Clear Telemetry Log"
+      },
+      {
+        "command": "nanofuzz.telemetry.log",
+        "title": "Log Telemetry Event (internal)"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nanofuzz",
   "version": "0.1.0",
   "displayName": "NaNofuzz",
-  "description": "Numeric Fuzzer for Typescript",
+  "description": "Automatic test generator for Typescript",
   "repository": "https://github.com/penrose/nanofuzz.git",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 import * as fp from "./ui/FuzzPanel";
 import * as tm from "./telemetry/Telemetry";
-import { fchmod } from "fs";
 
 const disposables: vscode.Disposable[] = []; // Keep track of disposables
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,9 @@
 import * as vscode from "vscode";
-import * as fuzzer from "./fuzzer/Fuzzer";
-import { FunctionRef } from "./fuzzer/Fuzzer";
-import { FuzzPanel, FuzzPanelStateSerialized } from "./ui/FuzzPanel";
+import * as fp from "./ui/FuzzPanel";
+import * as tm from "./telemetry/Telemetry";
+import { fchmod } from "fs";
 
-const languages = ["typescript", "typescriptreact"]; // Languages supported
-const commands = {
-  fuzz: "nanofuzz.Fuzz", // Commands supported
-};
+const disposables: vscode.Disposable[] = []; // Keep track of disposables
 
 /**
  * Called by VS Code to activates the extension.
@@ -14,66 +11,19 @@ const commands = {
  * @param context extension context provided by the VS Code extension host
  */
 export function activate(context: vscode.ExtensionContext): void {
-  //
+  tm.init(context);
+  fp.init(context);
+
   // --------------------------- Commands --------------------------- //
 
   /**
-   * Push the Fuzz command to the VS Code command palette.
+   * Push the commands to the VS Code command palette.
    */
-  context.subscriptions.push(
-    vscode.commands.registerCommand(
-      commands.fuzz,
-      async (match?: FunctionMatch) => {
-        // Get the function name (only present on a CodeLens match)
-        const fnName: string | undefined = match ? match.ref.name : undefined;
-
-        // Get the current active document
-        const editor = vscode.window.activeTextEditor;
-        const document = match
-          ? match.document
-          : vscode.window.activeTextEditor?.document;
-        if (!document || !editor) {
-          vscode.window.showErrorMessage(
-            "Please select a function to autotest in the editor."
-          );
-          return; // If there is no active editor, return.
-        }
-
-        // Ensure the document is saved / not dirty
-        if (document.isDirty) {
-          vscode.window.showErrorMessage(
-            "Please save the file before autotesting."
-          );
-          return;
-        }
-
-        // Get the current active editor filename
-        const srcFile = document.uri.path; //full path of the file which the function is in.
-
-        // Get the current cursor offset
-        const pos = match
-          ? match.ref.startOffset
-          : document.offsetAt(editor.selection.active);
-
-        // Call the fuzzer to analyze the function
-        const fuzzOptions = fuzzer.getDefaultFuzzOptions();
-        let fuzzSetup: fuzzer.FuzzEnv;
-        try {
-          fuzzSetup = fuzzer.setup(fuzzOptions, srcFile, fnName, pos);
-        } catch (e: any) {
-          vscode.window.showErrorMessage(
-            `Could not find or does not support this function. Messge: "${e.message}"`
-          );
-          return;
-        }
-
-        // Load the fuzz panel
-        FuzzPanel.render(context.extensionUri, fuzzSetup);
-
-        return;
-      }
-    )
-  ); // push command: nanofuzz.Fuzz
+  for (const cmd of Object.values({ ...fp.commands, ...tm.commands })) {
+    const reg = vscode.commands.registerCommand(cmd.name, cmd.fn);
+    context.subscriptions.push(reg);
+    disposables.push(reg);
+  }
 
   // ---------------------------- Panels ---------------------------- //
 
@@ -81,13 +31,13 @@ export function activate(context: vscode.ExtensionContext): void {
    * Register a FuzzPanelSerializer so the FuzzPanel window persists
    * across VS Code sessions.
    */
-  vscode.window.registerWebviewPanelSerializer(FuzzPanel.viewType, {
+  vscode.window.registerWebviewPanelSerializer(fp.FuzzPanel.viewType, {
     async deserializeWebviewPanel(
       webviewPanel: vscode.WebviewPanel,
-      state: FuzzPanelStateSerialized
+      state: fp.FuzzPanelStateSerialized
     ): Promise<void> {
       // Restore content of the webview.
-      FuzzPanel.revive(webviewPanel, context.extensionUri, state);
+      fp.FuzzPanel.revive(webviewPanel, context.extensionUri, state);
     },
   });
 
@@ -96,67 +46,29 @@ export function activate(context: vscode.ExtensionContext): void {
   /**
    * Push our CodeLens provider to the VS Code editor
    */
-  languages.forEach((lang) => {
-    context.subscriptions.push(
-      vscode.languages.registerCodeLensProvider(lang, { provideCodeLenses })
-    );
+  fp.languages.forEach((lang) => {
+    const lens = vscode.languages.registerCodeLensProvider(lang, {
+      provideCodeLenses: fp.provideCodeLenses,
+    });
+    context.subscriptions.push(lens);
+    disposables.push(lens);
   }); // push CodeLens provider
 
-  /**
-   * The CodeLens Provider
-   */
-  function provideCodeLenses(
-    document: vscode.TextDocument,
-    token: vscode.CancellationToken
-  ) {
-    // Use the TypeScript analyzer to find all fn declarations in the module
-    const matches: FunctionMatch[] = [];
-    try {
-      const functions = fuzzer.FunctionDef.find(
-        document.getText(),
-        document.fileName
-      );
-      for (const fn of functions) {
-        matches.push({
-          document,
-          ref: fn.getRef(),
-        });
-      }
-    } catch (e: any) {
-      console.error(
-        `Error parsing typescript file: ${document.fileName} error: ${e.message}`
-      );
-    }
+  // --------------------------- Listeners -------------------------- //
 
-    // Build the map of CodeLens objects at each function location
-    return matches.map(
-      (match) =>
-        new vscode.CodeLens(
-          new vscode.Range(
-            document.positionAt(match.ref.startOffset),
-            document.positionAt(match.ref.endOffset)
-          ),
-          {
-            title: "AutoTest...",
-            command: commands.fuzz,
-            arguments: [match],
-          }
-        )
-    );
-  } // fn: provideCodeLenses()
+  /**
+   * Push event listeners to VS Code
+   */
+  tm.listeners.forEach((listener) => {
+    context.subscriptions.push(listener.event(listener.fn));
+  });
 } // fn: activate()
 
 /**
  * De-activaton logic for the extension
  */
 export function deactivate(): void {
-  // !!!
+  disposables.forEach((e) => e.dispose());
+  fp.deinit();
+  tm.deinit();
 } // fn: deactivate()
-
-/**
- * Represents a link between a vscode document and a function definition
- */
-type FunctionMatch = {
-  document: vscode.TextDocument;
-  ref: FunctionRef;
-};

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -25,7 +25,6 @@ import * as vscode from "vscode";
  * - Type references
  * - Tuples
  * - OR types
- * - Non-primitive types
  * - Deconstructed types
  * - Generics
  */

--- a/src/telemetry/Logger.ts
+++ b/src/telemetry/Logger.ts
@@ -40,13 +40,10 @@ export class Logger {
     if (this.log.length) {
       const logCopy = this.log;
       this.log = []; // Clear the persisted data
-      console.debug(`Persisting chunk: ${chunkName}...`); // !!!
-      vscode.workspace.fs
-        .writeFile(chunkUri, Buffer.from(JSON.stringify(logCopy)))
-        .then(() => {
-          //this.memory.set(chunkName, this.log); // Persist this chunk
-          console.debug(`Persisted chunk: ${chunkName}`);
-        });
+      vscode.workspace.fs.writeFile(
+        chunkUri,
+        Buffer.from(JSON.stringify(logCopy))
+      );
     } else {
       console.debug("No log data to persist");
     }

--- a/src/telemetry/Logger.ts
+++ b/src/telemetry/Logger.ts
@@ -1,0 +1,100 @@
+import { Memory } from "./Memory";
+import * as util from "util";
+
+/**
+ * Lightweight storage for event data prior to de-staging.
+ */
+export class Logger {
+  constructor(private memory: Memory) {
+    this.calcPersist();
+  }
+  private log: LoggerEntry[] = [];
+  private oneMinute = 60000;
+  private chunkPrefix = `[Logger-Chunk]`;
+  private lastPersist: Date = new Date();
+  private nextPersist: Date = new Date(
+    this.lastPersist.getTime() + this.oneMinute
+  );
+  private calcPersist() {
+    this.lastPersist = new Date();
+    this.nextPersist = new Date(this.lastPersist.getTime() + this.oneMinute);
+  }
+  private persistChunk() {
+    const chunkName = `${this.chunkPrefix}${this.lastPersist.toISOString()}`;
+
+    this.calcPersist(); // Reset the persistence stamps
+    this.memory.set(chunkName, this.log); // Persist this chunk
+    this.log = []; // Clear the persisted data
+
+    console.debug(`Persisted chunk: ${chunkName}`);
+  }
+  public clear(): void {
+    this.log = [];
+    const keys: readonly string[] = this.memory.keys();
+    for (const keyidx in keys) {
+      const key: string = keys[keyidx];
+      if (key.startsWith(this.chunkPrefix)) {
+        this.memory.delete(key);
+        console.debug(`Deleted chunk: ${key}`);
+      }
+    }
+    console.debug(`Deleted log data`);
+  }
+  public push(logEntry: LoggerEntry): void {
+    this.log.push(logEntry);
+    console.debug(logEntry.toLogString());
+
+    if (new Date() > this.nextPersist) {
+      this.persistChunk(); // Persist if needed
+    }
+  }
+  public toJSON(): string {
+    // Flush any pending chunks to storage - so we get them in the next step.
+    if (this.log.length) {
+      this.persistChunk();
+    }
+
+    // Get each chunk from storage and re-construct the log
+    const fullLog: LoggerEntry[] = [];
+    const keys: readonly string[] = this.memory.keys();
+    for (const keyidx in keys) {
+      const key: string = keys[keyidx];
+      console.debug(`Evaluating key: ${key}`);
+      if (key.startsWith(this.chunkPrefix)) {
+        const chunk: LoggerEntry[] | undefined = this.memory.get(key);
+        if (chunk !== undefined) {
+          for (const chunkidx in chunk) {
+            fullLog.push(chunk[chunkidx]);
+          }
+          console.debug(`Loaded chunk: ${key}`);
+        }
+      }
+    }
+
+    return JSON.stringify(fullLog);
+  }
+}
+
+/**
+ * An entry in the log
+ */
+export class LoggerEntry {
+  constructor(
+    private src: string,
+    private msg?: string,
+    private prm?: string[]
+  ) {
+    this.time = new Date().toISOString();
+  }
+  private time: string;
+  public toLogString(): string {
+    const logStart = `${this.time}:${this.src}`;
+    if (this.msg === undefined) {
+      return logStart;
+    } else if (this.prm === undefined) {
+      return `${logStart}: ${this.msg}`;
+    } else {
+      return `${logStart}: ${util.format(this.msg, ...this.prm)}`;
+    }
+  }
+}

--- a/src/telemetry/Memory.ts
+++ b/src/telemetry/Memory.ts
@@ -1,0 +1,24 @@
+import * as vscode from "vscode";
+
+/**
+ * Front-end for the Memento VS Code persistence service
+ */
+export class Memory {
+  constructor(private memento: vscode.Memento) {}
+  public has(key: string): boolean {
+    return this.get(key) === undefined;
+  }
+  public get<T>(key: string): T | undefined {
+    return this.memento.get<T>(key);
+  }
+  public delete(key: string): void {
+    this.memento.update(key, undefined);
+  }
+  public set<T>(key: string, value: T): void {
+    console.debug(`Mementoizing ${key}`);
+    this.memento.update(key, value);
+  }
+  public keys(): readonly string[] {
+    return this.memento.keys();
+  }
+}

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -81,6 +81,12 @@ export const commands = {
       vscode.window.showInformationMessage("Log Data cleared");
     },
   },
+  logTelemetry: {
+    name: "nanofuzz.telemetry.log",
+    fn: (le?: LoggerEntry): void => {
+      if (le !== undefined && typeof le === "object") logger.push(le);
+    },
+  },
 };
 
 /**
@@ -282,3 +288,5 @@ vscode.window.registerTerminalLinkProvider({
     },
 });
 */
+
+export { LoggerEntry };

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -1,0 +1,281 @@
+import * as vscode from "vscode";
+import { Logger, LoggerEntry } from "./Logger";
+import { Memory } from "./Memory";
+
+let currentWindow = "";
+let currentTerm = "";
+let memory: Memory;
+let dataLog: Logger;
+let context: vscode.ExtensionContext;
+const config: PurseConfig = {};
+
+/**
+ * Initialize the module.
+ *
+ * @param context extension context
+ */
+export async function init(inContext: vscode.ExtensionContext): Promise<void> {
+  console.info("Telemetry is starting...");
+  context = inContext;
+
+  // Setup Workspace Storage
+  memory = new Memory(context.workspaceState);
+  dataLog = new Logger(memory);
+
+  // Load config
+  const cfg = vscode.workspace.getConfiguration("nanofuzz.telemetry");
+  config.timeoutMinutes = cfg.get("timeoutMinutes", 0);
+  config.purseCallbackUri = cfg.get("purseCallbackUri");
+  config.purseCallbackSecs = cfg.get("purseCallbackSecs", 15);
+  config.purseCallbackKey = cfg.get("purseCallbackKey");
+
+  console.info("Telemetry is active");
+}
+
+/**
+ * Called when extension is deactivated
+ */
+export function deinit(): void {
+  currentWindow = "";
+  currentTerm = "";
+
+  console.debug("Telemetry de-activated");
+}
+
+/**
+ * Filenames for code editors start with '/' or '\'
+ *
+ * @param fn filename
+ * @returns true if filename starts with '/' or '\'
+ */
+function isCodeEditor(fn: string): boolean {
+  return fn.charAt(0) === "/" || fn.charAt(0) === "\\";
+}
+
+/**
+ * Export this module's commands to the extension.
+ *
+ * Note: Manually update package.json.
+ */
+export const commands = {
+  dumpLog: {
+    name: "nanofuzz.telemetry.DumpLog",
+    fn: (): void => {
+      vscode.workspace
+        .openTextDocument({ content: dataLog.toJSON(), language: "json" })
+        .then((document) => {
+          vscode.window.showTextDocument(document);
+          vscode.window.showInformationMessage(
+            `Log Data dumped to document ${document.uri}`
+          );
+        });
+    },
+  },
+  clearLog: {
+    name: "nanofuzz.telemetry.ClearLog",
+    fn: (): void => {
+      dataLog.clear();
+      dataLog.push(new LoggerEntry("logDataCleared"));
+      vscode.window.showInformationMessage("Log Data cleared");
+    },
+  },
+};
+
+/**
+ * Export this module's listeners to the extension.
+ */
+export const listeners: Listener<any>[] = [
+  //
+  // ----------------------- Workspace Handlers ---------------------- //
+
+  {
+    event: vscode.workspace.onDidChangeConfiguration,
+    fn: (e: vscode.ConfigurationChangeEvent): void => {
+      dataLog.push(new LoggerEntry("onDidChangeConfiguration"));
+    },
+  },
+  {
+    event: vscode.workspace.onDidChangeTextDocument,
+    fn: (e: vscode.TextDocumentChangeEvent): void => {
+      for (const c of e.contentChanges) {
+        dataLog.push(
+          new LoggerEntry(
+            "onDidChangeTextDocument",
+            "%s:%s to %s:%s in [%s] replaced with: %s`",
+            [
+              c.range.start.line.toString(),
+              c.range.start.character.toString(),
+              c.range.end.line.toString(),
+              c.range.end.character.toString(),
+              e.document.fileName,
+              c.text,
+            ]
+          )
+        );
+      }
+    },
+  },
+
+  // ------------------------ Window Handlers ------------------------ //
+
+  {
+    event: vscode.window.onDidChangeActiveTextEditor,
+    fn: (editor: vscode.TextEditor | undefined): void => {
+      const previousWindow = currentWindow;
+      currentWindow =
+        editor !== undefined && isCodeEditor(editor.document.fileName)
+          ? editor.document.fileName
+          : "";
+      dataLog.push(
+        new LoggerEntry(
+          "onDidChangeActiveTextEditor",
+          "Current editor: [%s]; Previous editor: [%s]",
+          [currentWindow, previousWindow]
+        )
+      );
+    },
+  },
+  {
+    event: vscode.window.onDidChangeTextEditorSelection,
+    fn: (e: vscode.TextEditorSelectionChangeEvent): void => {
+      for (const s of e.selections) {
+        const selectedText = e.textEditor.document.getText(s);
+        dataLog.push(
+          new LoggerEntry(
+            "onDidChangeTextEditorSelection",
+            "%s:%s to %s:%s in [%s] text: %s",
+            [
+              s.start.line.toString(),
+              s.start.character.toString(),
+              s.end.line.toString(),
+              s.end.character.toString(),
+              e.textEditor.document.fileName,
+              selectedText,
+            ]
+          )
+        );
+      }
+    },
+  },
+  {
+    event: vscode.window.onDidChangeTextEditorVisibleRanges,
+    fn: (e: vscode.TextEditorVisibleRangesChangeEvent): void => {
+      for (const r of e.visibleRanges) {
+        dataLog.push(
+          new LoggerEntry(
+            "onDidChangeTextEditorVisibleRanges",
+            "%s:%s to %s:%s [%s]",
+            [
+              r.start.line.toString(),
+              r.start.character.toString(),
+              r.end.line.toString(),
+              r.end.character.toString(),
+              e.textEditor.document.fileName,
+            ]
+          )
+        );
+      }
+    },
+  },
+
+  // ----------------------- Terminal Handlers ----------------------- //
+
+  {
+    event: vscode.window.onDidOpenTerminal,
+    fn: (term: vscode.Terminal): void => {
+      dataLog.push(
+        new LoggerEntry("onDidOpenTerminal", "Opened terminal: [%s]", [
+          term.name,
+        ])
+      );
+    },
+  },
+  {
+    event: vscode.window.onDidChangeActiveTerminal,
+    fn: (term: vscode.Terminal | undefined): void => {
+      const previousTerm: string = currentTerm;
+      currentTerm = term === undefined ? "" : term.name;
+      dataLog.push(
+        new LoggerEntry(
+          "onDidChangeActiveTerminal",
+          "Current terminal: [%s]; Previous terminal: [%s]",
+          [currentTerm, previousTerm]
+        )
+      );
+    },
+  },
+  {
+    event: vscode.window.onDidChangeTerminalState,
+    fn: (term: vscode.Terminal): void => {
+      dataLog.push(
+        new LoggerEntry(
+          "onDidChangeTerminalState",
+          "Current terminal: [%s]; InteractedWith: [%s]",
+          [term.name, term.state.isInteractedWith ? "true" : "false"]
+        )
+      );
+    },
+  },
+  {
+    event: vscode.window.onDidCloseTerminal,
+    fn: (term: vscode.Terminal): void => {
+      dataLog.push(
+        new LoggerEntry("onDidCloseTerminal", "Closed terminal: [%s]", [
+          term.name,
+        ])
+      );
+    },
+  },
+];
+
+// ----------------------------- Types ----------------------------- //
+
+// !!!
+type Listener<T extends any> = {
+  event: vscode.Event<T>;
+  fn: (e: T) => void;
+};
+
+// !!!
+type PurseConfig = {
+  openMessage?: string; // Message to display on experiment start
+  timeoutMinutes?: number; // Devcontainer inactivity timeout
+  machineType?: string; // Devcontainer machine image type
+  purseCallbackUri?: string; // URI callback to PURSE experiment server
+  purseCallbackSecs?: number; // Interval (in seconds) for callback to PURSE
+  purseCallbackKey?: string; // Key for this experiment participant
+};
+
+/*
+function onDidTerminalOutput(context: vscode.TerminalLinkContext) {
+  dataLog.push(
+    new LoggerEntry("onDidTerminalOutput", "[%s] %s", [
+      context.terminal.name,
+      context.line,
+    ])
+  );
+}
+function onDidWriteTerminalData(context : vscode.TerminalDataWriteEvent) {
+	dataLog.push(new DataLogEntry('onDidWriteTerminalData','[%s] %s',
+		[
+			context.terminal.name,
+			context.data,
+		]
+	));
+}
+*/
+
+//context.subscriptions.push(vscode.window.onDidWriteTerminalData( e => onDidWriteTerminalData(e)));
+
+// Terminal Link Handlers
+/*
+vscode.window.registerTerminalLinkProvider({
+    provideTerminalLinks: (context, token) => {
+    onDidTerminalOutput(context);
+    return [];
+    },
+    handleTerminalLink: (link: any) => {
+    // noop
+    },
+});
+*/

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 import { Logger, LoggerEntry } from "./Logger";
 
-let currentWindow = ""; // !!!
-let currentTerm = ""; // !!!
-let logger: Logger; // !!!
-let context: vscode.ExtensionContext; // !!!
-let config: PurseConfig; // !!!
+let currentWindow = ""; // Current editor window filename / uri
+let currentTerm = ""; // Current terminal window name
+let logger: Logger; // Telemetry logger
+let context: vscode.ExtensionContext; // Context of this extension
+let config: PurseConfig; // Configuration settings
 
 /**
  * Initialize the module.
@@ -39,8 +39,9 @@ export function deinit(): void {
   currentTerm = "";
 
   /**
-   * The following code is usually not effective when the vscode
-   * window is closed.  For an explanation as to why, see:
+   * The following code is usually ineffective when the vscode window
+   * is closed. For an explanation as to why, see Microsoft's explanation
+   * below. The long and short of it is we may not be able to persist data.
    * https://github.com/microsoft/vscode/issues/122825#issuecomment-814218149
    */
   logger.flush();
@@ -231,7 +232,9 @@ export const listeners: Listener<any>[] = [
 
 // ----------------------------- Types ----------------------------- //
 
-// !!!
+/**
+ * Associates a callback function with an vscode event.
+ */
 type Listener<T extends any> = {
   event: vscode.Event<T>;
   fn: (e: T) => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "build/extension",
     "module": "commonjs",
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "WebWorker"],
     "sourceMap": true,
     "allowJs": true,
     "moduleResolution": "node",


### PR DESCRIPTION
# Description

This PR adds telemetry to the NaNofuzz extension.

# Implementation strategy and design decisions

This PR integrates the former `pursecode` extension into NaNofuzz.  Telemetry is persisted to a `telemetry` folder in the root of the project, which allows a simple commit of data to the repo fork/branch at the end of the session.

In addition to the normal `pursecode` telemetry, the following FuzzPanel events are also added:
- Opening a FuzzPanel
- Changing visibility or activeness of a FuzzPanel
- Executing the Fuzzer, including results.