### PR TITLE
chore: bump TS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "immutable": "^4.1.0",
     "json5": "^2.2.2",
     "seedrandom": "^3.0.5",
-    "typescript": "^4.1.3"
+    "typescript": "^4.9.5"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4621,10 +4621,10 @@ typedoc@^0.22.11:
     minimatch "^5.1.0"
     shiki "^0.10.1"
 
-typescript@^4.1.3:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Bump TypeScript version from ^4.1.3 to ^4.9.5. 

This resolves a large number of TypeScript errors and warnings in recent versions of VS Code.